### PR TITLE
Update library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -8,4 +8,3 @@ category=Signal Input/Output
 url=https://github.com/steenerson/Plex64
 architectures=
 includes=
-depends=Wire


### PR DESCRIPTION
Dependent on Wire library which is already part of Arduino.   Library fails to laoa because of this dependent (Wire) library which it cannot find